### PR TITLE
Maintain insertion order for processors with same priority

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10448,8 +10448,7 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
-      "dev": true
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
     },
     "lodash.startcase": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/frontity/h2r.git"
+  },
+  "dependencies": {
+    "lodash.sortby": "^4.7.0"
   }
 }

--- a/src/model/__tests__/index.tests.js
+++ b/src/model/__tests__/index.tests.js
@@ -81,4 +81,44 @@ describe('H2R Store', () => {
     expect(procs[4].test).toBe(processorLow.test);
     expect(procs[4].process).toBe(processorLow.process);
   });
+  test('maintain insertion order for processors with same priority', () => {
+    // Generate six processors
+    const processors = Array(6)
+      .fill(0)
+      .map(getProcessor);
+
+    // Array of priorities
+    const priorities = [30, 30, 20, 20, 10, 10];
+
+    // Add processors with their respective priority
+    processors.forEach((proc, i) => {
+      store.addProcessor(proc, priorities[i]);
+    });
+
+    const [
+      processorLow1,
+      processorLow2,
+      processorMedium1,
+      processorMedium2,
+      processorHigh1,
+      processorHigh2,
+    ] = processors;
+
+    const { processorsByPriority: sorted } = store;
+
+    expect(sorted).toHaveLength(6);
+
+    expect(sorted[0].test).toBe(processorHigh1.test);
+    expect(sorted[0].process).toBe(processorHigh1.process);
+    expect(sorted[1].test).toBe(processorHigh2.test);
+    expect(sorted[1].process).toBe(processorHigh2.process);
+    expect(sorted[2].test).toBe(processorMedium1.test);
+    expect(sorted[2].process).toBe(processorMedium1.process);
+    expect(sorted[3].test).toBe(processorMedium2.test);
+    expect(sorted[3].process).toBe(processorMedium2.process);
+    expect(sorted[4].test).toBe(processorLow1.test);
+    expect(sorted[4].process).toBe(processorLow1.process);
+    expect(sorted[5].test).toBe(processorLow2.test);
+    expect(sorted[5].process).toBe(processorLow2.process);
+  });
 });

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -1,5 +1,6 @@
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
 import { types } from 'mobx-state-tree';
+import sortBy from 'lodash.sortby';
 
 export const priorityValues = {
   high: 10,
@@ -14,7 +15,7 @@ export default types
   }))
   .views(self => ({
     get processorsByPriority() {
-      return self.processors.sort((p1, p2) => p1.priority - p2.priority);
+      return sortBy(self.processors, [({ priority }) => priority]);
     },
   }))
   .actions(self => ({


### PR DESCRIPTION
https://github.com/frontity/frontity/issues/112